### PR TITLE
Revises signInWithEmailAndPassword to return an either with the error or user credential

### DIFF
--- a/src/Firebase/Auth.purs
+++ b/src/Firebase/Auth.purs
@@ -36,7 +36,7 @@ import Data.Generic.Rep (class Generic)
 import Data.Maybe (Maybe(..))
 import Data.Nullable (Nullable, null, toMaybe)
 import Effect (Effect)
-import Effect.Aff (Aff)
+import Effect.Aff (Aff, Error, attempt)
 import Firebase.App (FirebaseApp)
 import Unsafe.Coerce (unsafeCoerce)
 
@@ -99,10 +99,10 @@ foreign import signInAnonymouslyImp :: Fn1 Auth (Effect (Promise Unit))
 signInAnonymously :: Auth -> Aff Unit
 signInAnonymously auth = runFn1 signInAnonymouslyImp auth # toAffE
 
-foreign import signInWithEmailAndPasswordImp :: Fn3 String String Auth (Effect (Promise Unit))
+foreign import signInWithEmailAndPasswordImp :: Fn3 String String Auth (Effect (Promise UserCredential))
 
-signInWithEmailAndPassword :: String -> String -> Auth -> Aff Unit
-signInWithEmailAndPassword email password auth = runFn3 signInWithEmailAndPasswordImp email password auth # toAffE
+signInWithEmailAndPassword :: String -> String -> Auth -> Aff (Either Error UserCredential)
+signInWithEmailAndPassword email password auth = runFn3 signInWithEmailAndPasswordImp email password auth # toAffE # attempt
 
 -- TODO: add Unsubscribe
 foreign import onAuthStateChangedImp :: Fn2 (Nullable User -> Effect Unit) Auth (Effect (Effect Unit))


### PR DESCRIPTION
I'm not sure how you'd like to design the API for this package, but I'm happy to contribute and follow your lead. I come from an Elm background in FP so let me know if I can make this more Pusescripty.

Some things I'd like to improve upon/discuss in this include:
- The `String -> String` part of the signature: Is it worth making a type for the email to battle passing the arguments in the wrong order?
- The `Error` type being returned: Should it be customized to account for Firebase's "auth/invalid-credential" case?
- There are no tests. Is it worth creating them?